### PR TITLE
import lint updates from haraka/.eslintrc

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# 1.0.8 - 2017-09-13
+
+* import rules from haraka/Haraka
+
 # 1.0.7 - 2017-06-16
 
 * Fixes the format of an eslint plugin. The "rules" section is for custom

--- a/index.js
+++ b/index.js
@@ -22,7 +22,12 @@ var recommendedRules = {
     // until this rule gets smart enough to realize that /\./ matches *only*
     // a literal dot and removing the \ does signficantly change the behavior,
     // this will be a warning only
-    "no-useless-escape": 1
+    "no-useless-escape": "warn",
+    "no-path-concat": "error",
+    "no-cond-assign": ["error", "except-parens"],
+    "no-constant-condition": ["error", { "checkLoops": false }],
+    "prefer-const": ["error", {"ignoreReadBeforeAssign": true}],
+    "no-var": "error"
 };
 
 // This is really here so we know how this "rules" section is used in the future

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-haraka",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "eslint rules for Haraka projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Consequences:
1. greenkeeper is going to freak out
2. all the haraka repos that include this (most of `haraka/haraka-*`) will need lint updates before their CI tests pass again.
